### PR TITLE
generate prisma schema before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN corepack enable
 RUN yarn install
 COPY . .
 RUN yarn build
-CMD ["sh", "-c", "yarn generate && yarn db:migrate:prod && node dist/index.js"]
+CMD ["sh", "-c", "yarn db:migrate:prod && node dist/index.js"]
 EXPOSE $SERVER_DOCKER_PORT

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx --watch src/index.ts",
-    "build": "rimraf dist && tsc && tsc-alias",
+    "build": "rimraf dist && yarn generate && tsc && tsc-alias",
     "generate": "prisma generate",
     "db:migrate:dev": "prisma migrate dev",
     "db:migrate:prod": "prisma migrate deploy",


### PR DESCRIPTION
Docker image cannot build due to type used from prisma client not generated before build